### PR TITLE
Add --no-legacy parameter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,7 @@
 v2.8 - not yet released
   - updated netfilter modules:
     * length2
+  - add parameter --no-legacy to not use xtables-legacy tools
 
 
 v2.7 - 5 May 2022

--- a/doc/ferm.pod
+++ b/doc/ferm.pod
@@ -2024,6 +2024,11 @@ seconds (see B<--timeout>).  This is useful for remote firewall
 administration: you can test the rules without fearing to lock
 yourself out.
 
+=item B<--no-legacy>
+
+Do not use xtables-legacy tools.  This is useful for administrators
+that wish to use the newer nftables backend.
+
 =item B<--timeout S>
 
 If B<--interactive> is used, then roll back if there is no valid user

--- a/src/ferm
+++ b/src/ferm
@@ -620,6 +620,7 @@ unshift @stack, {};
 # Get command line stuff
 if ($has_getopt) {
     my ($opt_noexec, $opt_flush, $opt_noflush, $opt_lines, $opt_interactive,
+        $opt_no_legacy,
         $opt_timeout, $opt_help,
         $opt_version, $opt_test, $opt_fast, $opt_slow, $opt_shell,
         $opt_domain);
@@ -657,6 +658,7 @@ if ($has_getopt) {
                remote => \$opt_test,
                fast => \$opt_fast,
                slow => \$opt_slow,
+               'no-legacy' => \$opt_no_legacy,
                shell => \$opt_shell,
                'domain=s' => \$opt_domain,
                'def=s' => \&opt_def,
@@ -680,6 +682,7 @@ if ($has_getopt) {
     $option{timeout} = defined $opt_timeout ? $opt_timeout : "30";
     $option{test} = $opt_test;
     $option{fast} = !$opt_slow;
+    $option{no_legacy} = $opt_no_legacy;
     $option{shell} = $opt_shell;
 
     foreach (@opt_test_mock_previous) {
@@ -883,14 +886,16 @@ sub find_tool($) {
     return $name if $option{test};
     my @path = ('/usr/sbin', '/sbin', split ':', $ENV{PATH});
 
-    if ($name =~ /^(.*tables)(.*)$/) {
-        # prefer the "legacy" xtables tools the new nft based tools
-        # are incompatible and sometimes break ferm
-        my $legacy_name = $1 . '-legacy' . $2;
-        foreach my $path (@path) {
-            my $ret = "$path/$legacy_name";
-            return $ret if -x $ret;
-        }
+    if (!$option{no_legacy}) {
+      if ($name =~ /^(.*tables)(.*)$/) {
+          # prefer the "legacy" xtables tools the new nft based tools
+          # are incompatible and sometimes break ferm
+          my $legacy_name = $1 . '-legacy' . $2;
+          foreach my $path (@path) {
+              my $ret = "$path/$legacy_name";
+              return $ret if -x $ret;
+          }
+      }
     }
 
     foreach my $path (@path) {
@@ -3236,6 +3241,7 @@ B<ferm> I<options> I<inputfiles>
  -V, --version     Show current version number
  -h, --help        Look at this text
  --slow            Slow mode, don't use iptables-restore
+ --no-legacy       Do not use xtables-legacy tools.
  --shell           Generate a shell script which calls iptables-restore
  --domain {ip|ip6} Handle only the specified domain
  --def '$name=v'   Override a variable


### PR DESCRIPTION
Since commit 47b78b6, ferm always uses legacy xtables tools. This commit allows users to revert to the old behaviour.